### PR TITLE
Set signature request expiry to end of day

### DIFF
--- a/src/app/api/signature-requests/route.ts
+++ b/src/app/api/signature-requests/route.ts
@@ -372,7 +372,16 @@ export async function POST(request: NextRequest) {
     }
 
     // Calculate expiration date
-    const expiresAt = dueDate ? new Date(dueDate) : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) // 30 days default
+    let expiresAt: Date
+    if (dueDate) {
+      // Set expiry to 11:59 PM (23:59:59) of the selected date
+      expiresAt = new Date(dueDate)
+      expiresAt.setHours(23, 59, 59, 999)
+    } else {
+      // Default: 30 days from now at 11:59 PM
+      expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+      expiresAt.setHours(23, 59, 59, 999)
+    }
 
     // Handle mock document IDs by creating a real document record first
     let realDocumentId = documentId

--- a/src/lib/multi-signature-service.ts
+++ b/src/lib/multi-signature-service.ts
@@ -87,7 +87,11 @@ export class MultiSignatureService {
           status: 'draft',
           created_by: createdBy,
           settings: JSON.stringify(settings),
-          expires_at: new Date(Date.now() + (settings.expiresInDays || 7) * 24 * 60 * 60 * 1000).toISOString()
+          expires_at: (() => {
+            const expiry = new Date(Date.now() + (settings.expiresInDays || 7) * 24 * 60 * 60 * 1000)
+            expiry.setHours(23, 59, 59, 999)
+            return expiry.toISOString()
+          })()
         }])
         .select()
         .single()

--- a/src/lib/signature-request-service.ts
+++ b/src/lib/signature-request-service.ts
@@ -42,9 +42,10 @@ export class SignatureRequestService {
     requestData: CreateSignatureRequestData
   ): Promise<SignatureRequest | null> {
     try {
-      // Calculate expiration date (default 30 days)
+      // Calculate expiration date (default 30 days) - set to 11:59 PM (23:59:59)
       const expiresAt = new Date()
       expiresAt.setDate(expiresAt.getDate() + (requestData.expiresInDays || 30))
+      expiresAt.setHours(23, 59, 59, 999)
 
       // Create the signature request
       const { data: signatureRequest, error: requestError } = await supabase
@@ -225,7 +226,7 @@ export class SignatureRequestService {
   }> {
     try {
       const requests = await this.getSignatureRequests(userId)
-      
+
       const counts = {
         total: requests.length,
         pending: requests.filter(r => r.status === 'pending').length,

--- a/src/lib/unified-signature-service.ts
+++ b/src/lib/unified-signature-service.ts
@@ -108,9 +108,10 @@ export class UnifiedSignatureService {
         return { success: false, error: 'Document not found' }
       }
 
-      // Calculate expiry date
+      // Calculate expiry date - set to 11:59 PM (23:59:59) of the expiry day
       const expires_at = new Date()
       expires_at.setDate(expires_at.getDate() + expires_in_days)
+      expires_at.setHours(23, 59, 59, 999)
 
       // Create signature request
       const { data: signatureRequest, error: requestError } = await this.supabase


### PR DESCRIPTION
Adjusts all signature request expiry calculations to set the time to 11:59:59 PM of the expiry date, ensuring requests expire at the end of the specified day rather than at the time of creation. This change improves consistency and user experience across the API and service layers.  ✅ Fix Complete: Expiry Date Now Set to 11:59 PM I've successfully fixed the expiry date issue. Now when you create a signature request and select a due date, it will be valid until 11:59 PM (23:59:59.999) of that selected date instead of 5:30 AM.

📝 Changes Made
I updated 4 files to ensure all expiry dates are set to end-of-day (11:59 PM):

 src/app/api/signature-requests/route.ts (Lines 374-384)
Main signature request creation endpoint
Sets expiry to 11:59 PM when a due date is selected Also sets default 30-day expiry to 11:59 PM

route.ts
src/app/api/signature-requests
src/lib/unified-signature-service.ts (Lines 111-114) src/lib/signature-request-service.ts (Lines 45-48) src/lib/multi-signature-service.ts (Lines 88-94)
🎯 What Changed
Before:

Expiry date: Oct 6, 2025 · 5:30 AM ❌
Users lose almost a full day of validity
After:

Expiry date: Oct 6, 2025 · 11:59 PM ✅
Users get the full day until the very end
🧪 Testing
To verify the fix:

Create a new signature request
Select a due date (e.g., October 6, 2025)
Submit the request
Check the expiry time - it should now show 11:59 PM instead of early morning The fix applies to:

✅ Custom due dates selected by users
✅ Default 30-day expiry (when no date is selected) ✅ All signature request creation flows
🔍 Technical Details
The fix uses JavaScript's setHours() method to set the time to:

Hours: 23 (11 PM)
Minutes: 59
Seconds: 59
Milliseconds: 999
This ensures the expiry is at the very last moment of the selected day, giving users the maximum validity period.